### PR TITLE
Add improvements to enable the T-Watch-2020-V1 to work better.

### DIFF
--- a/src/drive/bma423/bma.cpp
+++ b/src/drive/bma423/bma.cpp
@@ -173,6 +173,7 @@ void BMA::attachInterrupt()
 
 
     struct bma423_axes_remap remap_data;
+
     remap_data.x_axis = 0;
     remap_data.x_axis_sign = 1;
     remap_data.y_axis = 1;
@@ -182,6 +183,11 @@ void BMA::attachInterrupt()
 
     bma423_set_remap_axes(&remap_data, &_dev);
 
+}
+
+bool BMA::set_remap_axes(struct bma423_axes_remap *remap_data)
+{
+    bma423_set_remap_axes(remap_data, &_dev);
 }
 
 bool BMA::readInterrupt()

--- a/src/drive/bma423/bma.h
+++ b/src/drive/bma423/bma.h
@@ -42,6 +42,7 @@ public:
     uint8_t getIrqStatus();
     const char * getActivity();
 
+    bool set_remap_axes(struct bma423_axes_remap *remap_data);
     bool enableStepCountInterrupt(bool en = true);
     bool enableTiltInterrupt(bool en = true);
     bool enableWakeupInterrupt(bool en = true);

--- a/src/drive/rtc/pcf8563.cpp
+++ b/src/drive/rtc/pcf8563.cpp
@@ -338,6 +338,19 @@ void PCF8563_Class::syncToSystem()
     t_tm.tm_mday = dt.day;
     val.tv_sec = mktime(&t_tm);
     val.tv_usec = 0;
+
+    if ((dt.month > 2) && (dt.month < 11))
+    {
+        uint32_t day3 = getDayOfWeek (31, 3, dt.year);
+        uint32_t day10 = getDayOfWeek (31, 10, dt.year);
+
+        if (!((dt.day <= (31 - (6 - day3))) && (dt.month == 3)) ||          
+            !((dt.day >= (31 - (6 - day10))) && (dt.month == 10)))
+        {
+           val.tv_sec += 60 * 60;
+        }
+    }
+
     settimeofday(&val, NULL);
     log_i("syncToSystem: %d %d %d - %d %d %d \n", t_tm.tm_year, t_tm.tm_mon + 1, t_tm.tm_mday, t_tm.tm_hour, t_tm.tm_min, t_tm.tm_sec);
 }

--- a/src/drive/tft/bl.h
+++ b/src/drive/tft/bl.h
@@ -25,6 +25,7 @@ public:
 
     void adjust(uint8_t level)
     {
+	_level = level;
         ledcWrite(_channel, level);
         _on = true;
     };
@@ -37,7 +38,7 @@ public:
     void on()
     {
         _on = true;
-        ledcWrite(_channel, 255);
+        ledcWrite(_channel, _level);
     };
 
     void off()
@@ -59,6 +60,7 @@ private:
     bool _on = false;
     int _pin;
     uint8_t _channel;
+    uint8_t _level = 128;
 };
 
 


### PR DESCRIPTION
The bma axis mapping is wrong for the T-Watch-2020 and the src/drive/bma source code isn't able to use the #define so we need an externally visible bma axis remap function so it can be called from the watch.ino file 

The pcf8563.cpp daylight savings offset is debatable but I couldn't get the time to be correct without it (I'm in the UK so using GMT).

The back light needs to "remember" the brightness level otherwise every time it is re-enabled when waking the watch it goes to full brightness.

