### PR TITLE
Updated BMA423 axes for LILYGO_WATCH_2020_V1

### DIFF
--- a/src/TTGO.h
+++ b/src/TTGO.h
@@ -99,6 +99,17 @@ public:
 #ifdef LILYGO_WATCH_HAS_BMA423
         bma = new BMA(*i2c);
 #endif  /*LILYGO_WATCH_HAS_BMA423*/
+/*WATCH 2020 needs different axes so that the tilt function works*/
+#ifdef LILYGO_WATCH_2020_V1
+	struct bma423_axes_remap remap_data;
+	remap_data.x_axis = 0;
+	remap_data.x_axis_sign = 1;
+	remap_data.y_axis = 1;
+	remap_data.y_axis_sign = 0;
+	remap_data.z_axis  = 2;
+	remap_data.z_axis_sign  = 1;
+	bma->remapTiltAxes(remap_data);
+#endif
 
 #ifdef LILYGO_WATCH_HAS_BUTTON
         //In the 2020 version, Button IO36 is not used.

--- a/src/drive/bma423/bma.cpp
+++ b/src/drive/bma423/bma.cpp
@@ -6,6 +6,15 @@ I2CBus *BMA::_bus = nullptr;
 BMA::BMA(I2CBus &bus)
 {
     _bus = &bus;
+    
+    //Default tilt mapping
+    //2020_V1 watch needs different mapping
+    tilt_mapping.x_axis = 0;
+    tilt_mapping.x_axis_sign = 1;
+    tilt_mapping.y_axis = 1;
+    tilt_mapping.y_axis_sign = 1;
+    tilt_mapping.z_axis  = 2;
+    tilt_mapping.z_axis_sign  = 0;
 }
 
 BMA::~BMA()
@@ -171,18 +180,12 @@ void BMA::attachInterrupt()
 
     // Serial.printf("[bma4] attachInterrupt %s\n", rslt != 0 ? "fail" : "pass");
 
+    bma423_set_remap_axes(&tilt_mapping, &_dev);
 
-    struct bma423_axes_remap remap_data;
+}
 
-    remap_data.x_axis = 0;
-    remap_data.x_axis_sign = 1;
-    remap_data.y_axis = 1;
-    remap_data.y_axis_sign = 1;
-    remap_data.z_axis  = 2;
-    remap_data.z_axis_sign  = 0;
-
-    bma423_set_remap_axes(&remap_data, &_dev);
-
+void BMA::remapTiltAxes(struct bma423_axes_remap data){
+    tilt_mapping = data;
 }
 
 bool BMA::set_remap_axes(struct bma423_axes_remap *remap_data)

--- a/src/drive/bma423/bma.h
+++ b/src/drive/bma423/bma.h
@@ -48,6 +48,7 @@ public:
     bool enableWakeupInterrupt(bool en = true);
     bool enableAnyNoMotionInterrupt(bool en = true);
     bool enableActivityInterrupt(bool en = true);
+    void remapTiltAxes(struct bma423_axes_remap data);
 
 private:
     static uint16_t read(uint8_t dev_addr, uint8_t reg_addr, uint8_t *read_data, uint16_t len);
@@ -60,5 +61,7 @@ private:
     static I2CBus *_bus;
     bool _irqRead = false;
     uint16_t _irqStatus;
+    struct bma423_axes_remap tilt_mapping;
 
 };
+


### PR DESCRIPTION
In the method attachInterrupt, the mapping for the axes are incorrect for the 2020_V1. 

This pull requests added a method remapTiltAxes and an instance variable tilt_mapping to the BMA class.

tilt_mapping is initialized to the original mapping in the BMA constructor.

If LILYGO_TWATCH_2020_V1 is defined, then in TTGO.h the BMA::remapTiltAxes method is called and passed the new axes mapping for the 2020 V1.

The attachInterrupt was updated to simple pass the tilt_mapping instance variable to the bma423_set_remap_axes function.