### PR TITLE
cleanup and fixes to bl.h

### DIFF
--- a/examples/LVGL/SimpleWatch/gui.cpp
+++ b/examples/LVGL/SimpleWatch/gui.cpp
@@ -1162,13 +1162,13 @@ static void wifi_sync_mbox_cb(lv_task_t *t)
             pl = nullptr;
 
             char format[256];
-            snprintf(format, sizeof(format), "Time acquisition is:%d-%d-%d/%d:%d:%d, Whether to synchronize?", timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday, timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
+            snprintf(format, sizeof(format), "Time acquisition is: %d-%d-%d/%d:%d:%d. Synchronize?", timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday, timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
             Serial.println(format);
             delete task;
             task = nullptr;
 
             //! mbox
-            static const char *btns[] = {"Ok", "Cancle", ""};
+            static const char *btns[] = {"Ok", "Cancel", ""};
             mbox = new MBox;
             mbox->create(format, [](lv_obj_t *obj, lv_event_t event) {
                 if (event == LV_EVENT_VALUE_CHANGED) {
@@ -1181,9 +1181,9 @@ static void wifi_sync_mbox_cb(lv_task_t *t)
 
                         TTGOClass *ttgo = TTGOClass::getWatch();
                         ttgo->rtc->setDateTime(info->tm_year + 1900, info->tm_mon + 1, info->tm_mday, info->tm_hour, info->tm_min, info->tm_sec);
-                    } else if (!strcmp(txt, "Cancle")) {
-                        //!cancle
-                        // Serial.println("Cancle press");
+                    } else if (!strcmp(txt, "Cancel")) {
+                        //!cancel
+                        // Serial.println("Cancel press");
                     }
                     delete mbox;
                     mbox = nullptr;

--- a/src/board/twatch2020_v1.h
+++ b/src/board/twatch2020_v1.h
@@ -11,8 +11,8 @@
 #define TWATCH_TFT_RST              (gpio_num_t)-1
 #define TWATCH_TFT_BL               (gpio_num_t)12
 
-#define TOUCH_SDA                      23
-#define TOUCH_SCL                      32
+#define TOUCH_SDA                   23
+#define TOUCH_SCL                   32
 #define TP_INT                      38
 
 #define SEN_SDA                     21


### PR DESCRIPTION
- Consolidated PWM functions into base classes.
- Removed channel hardcoding for onec() in Motor and Buzzer classes (using once_ms<uint8_t>)
- reduced type size for channel and pin members
- safe init and delete for Ticker

twatch2020_v1.h
- Fixed whitespace issues