### PR TITLE
re-added bma_begin

### DIFF
--- a/examples/LVGL/SimpleWatch/SimpleWatch.ino
+++ b/examples/LVGL/SimpleWatch/SimpleWatch.ino
@@ -128,6 +128,9 @@ void setup()
     //Initialize lvgl
     ttgo->lvgl_begin();
 
+    //Initialize bma423
+    ttgo->bma->begin();
+
     // Enable BMA423 interrupt ，
     // The default interrupt configuration,
     // you need to set the acceleration parameters, please refer to the BMA423_Accel example


### PR DESCRIPTION
BUGFIX: without bma->begin() T-watch 2020v1 cause the following error:

**Guru Meditation Error: Core 1 panic'ed (InstrFetchProhibited). Exception was unhandled.**