### PR TITLE
rotate does not work properly if LILYGO_WATCH_2020_V1 define

### DIFF
--- a/src/TTGO.h
+++ b/src/TTGO.h
@@ -805,12 +805,15 @@ protected:
         case 0:
             x = TFT_WIDTH - p.x;
             y = TFT_HEIGHT - p.y;
+	          break;
         case 1:
             x = TFT_WIDTH - p.y;
-            y = TFT_HEIGHT - p.x;
+            y = p.x;
+	          break;
         case 3:
             x = p.y;
             y = TFT_HEIGHT - p.x;
+            break;
         case 2:
         default:
             x = p.x;


### PR DESCRIPTION
Wrong use of the switch case statementt, so that the touchscreen coordinates are not rotated with the TFT and the default branch is always executed last.