### PR TITLE
Fix time sync

### DIFF
--- a/examples/LVGL/SimpleWatch/gui.cpp
+++ b/examples/LVGL/SimpleWatch/gui.cpp
@@ -429,6 +429,8 @@ static void updateTime()
     strftime(buf, sizeof(buf), "%H:%M", &info);
     lv_label_set_text(timeLabel, buf);
     lv_obj_align(timeLabel, NULL, LV_ALIGN_IN_TOP_MID, 0, 20);
+    TTGOClass *ttgo = TTGOClass::getWatch();
+    ttgo->rtc->syncToRtc();
 }
 
 void updateBatteryLevel()


### PR DESCRIPTION
_This is the same as [this PR](https://github.com/Xinyuan-LilyGO/TTGO_TWatch_Library/pull/55), which was closed (and I can't re-open), but with stronger justification._

There are several issues with the code present for doing NTP syncing (more fully described in the individual commits that make up this pull request).

I think the simplest working example is to merely make it a "do NTP sync now" button.

Adding some detail - as it stands, **the synchronization will almost always sync to the wrong time**:

* The function doesn't wait for NTP to actually happen, it's just started - so the clock is still wrong.
  (This will ~always be the case, unless your NTP server is REALLY fast)

* The current time is passed as static data, and is then pushed into the RTC after the UI interaction - making it stale.
  (This will always make the time slow by a few seconds - however long you keep the OK/Cancel dialog open)

* NTP may complete during the UI interaction, and then get stomped on.
  (This is probably the most common outcome; the NTP sync completes while the dialog is up, the user hits "OK", and then the wrong time captured before the dialog is re-saved to be the "current time").

* If you hit cancel, the NTP sequence still completes and updates the watch's local time (though it won't reliably be persisted to the RTC, so the watch will probably return to the previous time after a while).

The best sync you can do right now, is to select to do the sync; cancel the dialog (this lets NTP do its thing). Then select to do a sync and IMMEDIATELY click "OK" (this updates the RTC).