### PR TITLE
 allows lvgl to use psram if it is available

### DIFF
--- a/src/lv_conf.h
+++ b/src/lv_conf.h
@@ -93,7 +93,11 @@ typedef int16_t lv_coord_t;
 #  define LV_MEM_AUTO_DEFRAG  1
 #else       /*LV_MEM_CUSTOM*/
 #  define LV_MEM_CUSTOM_INCLUDE <stdlib.h>   /*Header for the dynamic memory function*/
+#if defined(BOARD_HAS_PSRAM)
+#  define LV_MEM_CUSTOM_ALLOC   ps_malloc       /*Wrapper to malloc*/
+#else
 #  define LV_MEM_CUSTOM_ALLOC   malloc       /*Wrapper to malloc*/
+#endif
 #  define LV_MEM_CUSTOM_FREE    free         /*Wrapper to free*/
 #endif     /*LV_MEM_CUSTOM*/
 


### PR DESCRIPTION
lvgl consumes relatively much memory during intensive use. the change allows lvgl to use psram and saves internal ram at runtime.