### PR TITLE
Update FT5206.h

### DIFF
--- a/src/TTGO.h
+++ b/src/TTGO.h
@@ -333,6 +333,17 @@ public:
         power->setLDO3Mode(1);
         power->setPowerOutPut(AXP202_LDO3, en);
     }
+  
+      /*
+     * @brief Turn off all AXP202 outputs except LDO1.
+     * This is equivalent to holding the power button for 6s
+     * Current consumption in the shutdown state is <350uA
+     *
+     * Restart by pressing power button for 2s
+     */
+    void soft_hardShutdown(){
+        power->shutdown();
+    }
 
 
 

--- a/src/drive/fx50xx/FT5206.h
+++ b/src/drive/fx50xx/FT5206.h
@@ -38,7 +38,8 @@ github:https://github.com/lewisxhe/FT5206_Library
 #define FT5206_VENDID_REG       (0xA8)
 #define FT5206_CHIPID_REG       (0xA3)
 #define FT5206_THRESHHOLD_REG   (0x80)
-#define FT5206_POWER_REG        (0x87)
+#define FT5206_TIMEENTERMONITOR (0x87)  //Cant seem to change this?
+#define FT5206_POWER_REG        (0xA5)
 
 #define FT5206_MONITOR         (0x01)
 #define FT5206_SLEEP_IN        (0x03)


### PR DESCRIPTION
For the TTGO T Watch 2020 V1, FT6236 Touch Controller:

POWER_REG was defined as 0x87, this is the TIMENTERMONITOR register. 
Suggestion: Replace incorrect POWER_REG define (0x87) with correct address 0xA5.
Note: Writing 0x01 to 0xA5 puts the chip into monitor mode directly.
Note: Writing 0x03 to 0xA5 puts the chip into sleep mode, but recovery requires access to the RST line of the controller, or a complete power cycle.
Sidenote: TIMEENTERMONITOR register appears to have no function as all writes seem to produce no change to the default 30 second no touch timeout from active to monitor mode.