### PR TITLE
Bugfix: Incorrect power register defined in FT5206.h

### DIFF
--- a/src/drive/fx50xx/FT5206.h
+++ b/src/drive/fx50xx/FT5206.h
@@ -38,7 +38,8 @@ github:https://github.com/lewisxhe/FT5206_Library
 #define FT5206_VENDID_REG       (0xA8)
 #define FT5206_CHIPID_REG       (0xA3)
 #define FT5206_THRESHHOLD_REG   (0x80)
-#define FT5206_POWER_REG        (0x87)
+#define FT5206_TIMEENTERMONITOR (0x87)  //Time to go from Active to monitor state, has no effect?
+#define FT5206_POWER_REG        (0xA5)  //This directly controls the power state
 
 #define FT5206_MONITOR         (0x01)
 #define FT5206_SLEEP_IN        (0x03)


### PR DESCRIPTION
Previously, power reg was listed as 0x87 which is actually the TIMEENTERMONITOR register.

The correct register is 0xA5, writing FT5206_MONITOR to it now correctly causes the chip to enter monitor mode.

Sleep still doesn't work in this case, as you have determined without access to the reset line there is no way to pull the chip out of sleep.