### PR TITLE
bugfixes:

### DIFF
--- a/src/drive/rtc/pcf8563.cpp
+++ b/src/drive/rtc/pcf8563.cpp
@@ -85,7 +85,7 @@ void PCF8563_Class::setDateTime(uint16_t year,
     _data[5] = _dec_to_bcd(month);
     _data[6] = _dec_to_bcd(year % 100);
 
-    if (2000 - year  - (year % 100)) {
+    if ( year < 2000) {
         _data[4] |= PCF8563_CENTURY_MASK;
     } else {
         _data[4] &= (~PCF8563_CENTURY_MASK);
@@ -349,7 +349,7 @@ void PCF8563_Class::syncToRtc()
     struct tm  info;
     time(&now);
     localtime_r(&now, &info);
-    setDateTime(info.tm_year, info.tm_mon + 1, info.tm_mday, info.tm_hour, info.tm_min, info.tm_sec);
+    setDateTime(info.tm_year + 1900, info.tm_mon + 1, info.tm_mday, info.tm_hour, info.tm_min, info.tm_sec);
     // Serial.printf("syncToRtc: %d %d %d - %d %d %d \n", info.tm_year, info.tm_mon + 1, info.tm_mday, info.tm_hour, info.tm_min, info.tm_sec);
 }
 


### PR DESCRIPTION
1) the check `if (2000 - year  - (year % 100))` is wrong and actually too
complicated. the correct condition should be `if (2000 - year  + (year % 100))`
or `if (2000 - (year  - (year % 100)))` but in base of the pcf8563 data-sheet
the behavior of the C flag is simple `0 indicates the century is 20xx, 1
indicates the century is 19xx`. I guess the condition `if ( year < 2000)`
is exactly what should be checked.

2) tm structure used in syncToRtc provides year from 1900 that means, for
the year 2020 is provided number 120. Function getDayOfWeek used in
setDateTime expects year in full format and therefore is set a wrong day
of week to RTC. It can cause starting of alarm in wrong day.