### PR TITLE
Avoid prototyping warning

### DIFF
--- a/src/lv_conf.h
+++ b/src/lv_conf.h
@@ -94,6 +94,12 @@ typedef int16_t lv_coord_t;
 #else       /*LV_MEM_CUSTOM*/
 #  define LV_MEM_CUSTOM_INCLUDE <stdlib.h>   /*Header for the dynamic memory function*/
 #if defined(BOARD_HAS_PSRAM)
+      /* Until Espressif corrects their own hearder */
+#  include <stddef.h>
+#  include <stdbool.h>
+
+      /* declare ps_malloc()'s prototype */
+#  include <esp32-hal-psram.h>
 #  define LV_MEM_CUSTOM_ALLOC   ps_malloc       /*Wrapper to malloc*/
 #else
 #  define LV_MEM_CUSTOM_ALLOC   malloc       /*Wrapper to malloc*/


### PR DESCRIPTION
ps_malloc() is not defined and create a compilation warning.
Worst, it's preventing compilation if the compiler is set in strict mode.