### PR TITLE
Changes PWM channel to avoid backlight/motor conflict

### DIFF
--- a/src/drive/tft/bl.h
+++ b/src/drive/tft/bl.h
@@ -120,7 +120,7 @@ protected:
 class Motor : public PWMToneBase
 {
 public:
-    Motor(uint8_t pin, uint8_t channel = 1, int freq = 1000) : PWMToneBase(pin, channel, freq)
+    Motor(uint8_t pin, uint8_t channel = 4, int freq = 1000) : PWMToneBase(pin, channel, freq)
     {
     };
 };


### PR DESCRIPTION
Currently the backlight and vibration motor are on PWM channels 0 and 1 respectively which both share a timer. This causes backlight to dim when motor is used as it seems to change the frequency/duty cycle so that the backlight can't show full brightness. I have changed the motor channel number which avoids interference with either the backlight or the buzzer PWM timers. 