### PR TITLE
Typo: bool AXP20X_Class::isPEKLongtPressIRQ()

### DIFF
--- a/examples/T-Block/Epaper_Badge/Epaper_Badge.ino
+++ b/examples/T-Block/Epaper_Badge/Epaper_Badge.ino
@@ -622,7 +622,7 @@ void loop()
 #ifdef LILYGO_WATCH_HAS_BACKLIGHT
             twatch->bl->isOn() ? twatch->bl->off() : twatch->bl->adjust(DEFAULT_BRIGHTNESS);
 #endif
-        } else if (power->isPEKLongtPressIRQ()) {
+        } else if (power->isPEKLongPressIRQ()) {
 
             Serial.println("enter power off!!!!");
             /**

--- a/src/drive/axp/axp20x.cpp
+++ b/src/drive/axp/axp20x.cpp
@@ -753,7 +753,7 @@ bool AXP20X_Class::isPEKShortPressIRQ()
     return (bool)(_irq[2] & BIT_MASK(1));
 }
 
-bool AXP20X_Class::isPEKLongtPressIRQ()
+bool AXP20X_Class::isPEKLongPressIRQ()
 {
     return (bool)(_irq[2] & BIT_MASK(0));
 }

--- a/src/drive/axp/axp20x.h
+++ b/src/drive/axp/axp20x.h
@@ -608,7 +608,7 @@ public:
     bool isBattTempHighIRQ();
 
     bool isPEKShortPressIRQ();
-    bool isPEKLongtPressIRQ();
+    bool isPEKLongPressIRQ();
     bool isTimerTimeoutIRQ();
 
     //! Group4 ADC data


### PR DESCRIPTION
Present in library code is typo'd function `IsPEKLongtPressIRQ()`.

Clearly a copy-paste related typo duplicating name of `IsPEKShortPressIRQ()`.

This should be `isPEKLongPressIRQ()` in all instances.

Obviously not a big deal, but also obviously not intentional.