### PR TITLE
Adding option to put the LoRa module to sleep

### DIFF
--- a/src/LilyGoLib.cpp
+++ b/src/LilyGoLib.cpp
@@ -528,6 +528,12 @@ void LilyGoLib::setSleepMode(SleepMode_t mode)
     sleepMode = mode;
 }
 
+void LilyGoLib::sleepLora(bool config){
+    #ifdef USING_TWATCH_S3
+        SX126x::sleep(config);
+    #endif
+}
+
 void LilyGoLib::sleep(uint32_t second)
 {
     // SX126x::sleep();

--- a/src/LilyGoLib.h
+++ b/src/LilyGoLib.h
@@ -142,7 +142,7 @@ public:
 
     bool readMicrophone(void *dest, size_t size, size_t *bytes_read, TickType_t ticks_to_wait = portMAX_DELAY);
 
-
+    void sleepLora(bool config);
     void setSleepMode(SleepMode_t mode);
 
     void sleep(uint32_t second) ;


### PR DESCRIPTION
I don't see a way to put the SX126x to sleep. So I added one. I do not like the name because the method should be called sleep but that name is already used