### PR TITLE
Improvement of setBrightness

### DIFF
--- a/src/LilyGoLib.cpp
+++ b/src/LilyGoLib.cpp
@@ -293,7 +293,7 @@ void LilyGoLib::setBrightness(uint8_t level)
         writecommand(0x10);  //display sleep
         setPowerMode(PMODE_MONITOR);
     }
-    if (!brightness) {
+    if (!brightness && level != 0) {
         enableALDO2();
         writecommand(0x11);  //display wakeup
     }


### PR DESCRIPTION
If you call `setBrightness(0)` twice, the screen power on.
This change fixes that situation.