### PR TITLE
fix: replace memset with value initialization for uBloxGnssModelInfo

### DIFF
--- a/src/LilyGoLib.cpp
+++ b/src/LilyGoLib.cpp
@@ -679,7 +679,7 @@ bool LilyGoLib::gpsProbe()
 
     uint16_t len = getAck(buffer, 256, 0x0A, 0x04);
     if (len) {
-        memset(&info, 0, sizeof(info));
+        info = uBloxGnssModelInfo{};
         uint16_t position = 0;
         for (int i = 0; i < 30; i++) {
             info.softVersion[i] = buffer[position];


### PR DESCRIPTION
Using memset on a non-trivial type like uBloxGnssModelInfo
triggers -Wclass-memaccess warnings and may lead to undefined
behavior in C++. This patch replaces memset with proper
value-initialization, ensuring safe and portable initialization
of the struct.

Tested on ESP32-S3 (LilyGo T-Watch S3).